### PR TITLE
Update spearman.py

### DIFF
--- a/example/train_reloss/spearman.py
+++ b/example/train_reloss/spearman.py
@@ -11,6 +11,7 @@ def diffsort_rank(x):
         sorter = DiffSortNet('bitonic',
                              x.shape[1],
                              steepness=5,
+                             interpolation_type='logistic_phi',
                              device=x.device)
         sorter_shape = x.shape[1]
 


### PR DESCRIPTION
In https://arxiv.org/abs/2203.09630, we propose monotonic differentiable sorting networks which perform better than logistic with ART. Thus, we changed the default `interpolation_type` to `cauchy` in our recent update to `diffsort`. While cauchy might work better, I suggest specifying the interpolation type explicitly for reproducibility. 

Best regards,

Felix